### PR TITLE
스프링 시큐리티 인증 방식 수정

### DIFF
--- a/MSA-api-gateway/src/main/java/com/joh/apigateway/security/JwtAuthenticationFilter.java
+++ b/MSA-api-gateway/src/main/java/com/joh/apigateway/security/JwtAuthenticationFilter.java
@@ -70,6 +70,7 @@ public class JwtAuthenticationFilter implements WebFilter {
                           return jwtUtil.createAccessToken(oauthId)
                               .flatMap(newAccessToken -> {
 
+                                System.out.println("X-ACCESS-TOKEN 활성화");
                                 exchange.getResponse().getHeaders().add("X-ACCESS-TOKEN", newAccessToken);
 
                                 return chain.filter(exchange)

--- a/MSA-api-gateway/src/main/java/com/joh/apigateway/security/SecurityConfig.java
+++ b/MSA-api-gateway/src/main/java/com/joh/apigateway/security/SecurityConfig.java
@@ -1,9 +1,6 @@
 package com.joh.apigateway.security;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,7 +10,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
-import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity.CsrfSpec;
 import org.springframework.security.config.web.server.ServerHttpSecurity.FormLoginSpec;
@@ -22,7 +18,6 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.reactive.CorsConfigurationSource;
 import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
-import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 @Configuration
@@ -33,18 +28,12 @@ public class SecurityConfig {
   @Bean
   public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
 
-    System.out.println("아니 왜 안 되는데;;");
-
     return http
         .csrf(CsrfSpec::disable)
         .httpBasic(HttpBasicSpec::disable)
         .formLogin(FormLoginSpec::disable)
         .exceptionHandling(exceptions -> exceptions
             .authenticationEntryPoint((exchange, ex) -> {
-
-//          System.out.println("시발 왜? - " + ex.getCause().getMessage());
-//          System.out.println("토큰: " + exchange.getRequest().getCookies().getFirst("accessToken"));
-//          System.out.println("uri: " + exchange.getRequest().getURI());
 
           // HTTP 상태 401로 응답 작성
           exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);

--- a/MSA-api-gateway/src/main/java/com/joh/apigateway/security/SecurityConfig.java
+++ b/MSA-api-gateway/src/main/java/com/joh/apigateway/security/SecurityConfig.java
@@ -64,6 +64,7 @@ public class SecurityConfig {
     config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS")); // 허용 HTTP 메서드
     config.setAllowedHeaders(List.of("*")); // 모든 헤더 허용
     config.setAllowCredentials(true); // 쿠키 허용
+    config.setExposedHeaders(List.of("X-ACCESS-TOKEN"));
 
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", config); // 모든 경로에 대해 CORS 설정 적용

--- a/MSA-core/src/main/java/com/joh/core/club/model/Club.java
+++ b/MSA-core/src/main/java/com/joh/core/club/model/Club.java
@@ -1,5 +1,5 @@
 package com.joh.core.club.model;
 
-public class EplClub {
+public class Club {
 
 }

--- a/MSA-core/src/main/java/com/joh/core/club/repository/ClubRepository.java
+++ b/MSA-core/src/main/java/com/joh/core/club/repository/ClubRepository.java
@@ -1,0 +1,8 @@
+package com.joh.core.club.repository;
+
+import com.joh.core.club.model.Club;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+
+public interface ClubRepository extends ReactiveMongoRepository<Club, String> {
+
+}

--- a/MSA-core/src/main/java/com/joh/core/club/repository/EplClubRepository.java
+++ b/MSA-core/src/main/java/com/joh/core/club/repository/EplClubRepository.java
@@ -1,8 +1,0 @@
-package com.joh.core.club.repository;
-
-import com.joh.core.club.model.EplClub;
-import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
-
-public interface EplClubRepository extends ReactiveMongoRepository<EplClub, String> {
-
-}

--- a/MSA-core/src/main/java/com/joh/core/user/dto/UserResponse.java
+++ b/MSA-core/src/main/java/com/joh/core/user/dto/UserResponse.java
@@ -11,11 +11,13 @@ public class UserResponse {
   private String email;
   private String nickname;
   private String profileImage;
+  private String accessToken;
 
   @Builder
-  public UserResponse(String email, String nickname, String profileImage) {
+  public UserResponse(String email, String nickname, String profileImage, String accessToken) {
     this.email = email;
     this.nickname = nickname;
     this.profileImage = profileImage;
+    this.accessToken = accessToken;
   }
 }

--- a/MSA-core/src/main/java/com/joh/core/user/mapper/UserMapper.java
+++ b/MSA-core/src/main/java/com/joh/core/user/mapper/UserMapper.java
@@ -7,12 +7,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class UserMapper {
 
-  public UserResponse toUserResponse(User user) {
+  public UserResponse toUserResponse(User user, String accessToken) {
 
     return UserResponse.builder()
         .email(user.getEmail())
         .nickname(user.getNickname())
         .profileImage(user.getProfileImage())
+        .accessToken(accessToken)
         .build();
   }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- fix/auth -> main

### 변경 사항
- 기존 쿠키 인증 방식에서 헤더 인증 방식으로 수정함
- 엑세스 토큰이 만료 되었지만 리프레시 토큰은 살아 있다면, 엑세스 토큰을 새로 생성한 다음 X-ACCESS-TOKEN에 토큰값을 넣어서 요청을 응답해줌
- 프론트엔드에선 새로 발급 받은 토큰 값을 인증 헤더에 재설정 해줌
- 이후 백엔드에선 커스텀 헤더 제거

### 테스트 결과
![image](https://github.com/user-attachments/assets/f2b01b85-d8fe-4be6-a722-46e7f2d67120)

![image](https://github.com/user-attachments/assets/05e2ae3a-f282-46cc-9024-0706d77c5189)
