### PR TITLE
매도 API 추가

### DIFF
--- a/MSA-coin/src/main/java/com/joh/coin/controller/OrderController.java
+++ b/MSA-coin/src/main/java/com/joh/coin/controller/OrderController.java
@@ -26,8 +26,9 @@ public class OrderController {
   }
 
   @PostMapping("/sell")
-  public Mono<?> sellCoin(@RequestBody TradeOrderReq tradeOrderReq) {
+  public Mono<ResponseEntity<TradeOrderRes>> sellCoin(@RequestBody TradeOrderReq tradeOrderReq) {
 
-    return null;
+    return orderBookService.sellCoin("testID", tradeOrderReq)
+        .map(result -> ResponseEntity.ok().body(result));
   }
 }

--- a/MSA-coin/src/main/java/com/joh/coin/entity/OrderBook.java
+++ b/MSA-coin/src/main/java/com/joh/coin/entity/OrderBook.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
@@ -38,11 +39,13 @@ public class OrderBook {
   @Column("created_at")
   private LocalDateTime createdAt;
 
+  @Setter
   @Column("updated_at")
   private LocalDateTime updatedAt;
 
   public void updateStatusToCompleted() {
     this.status = OrderStatus.COMPLETED.name();
+    this.updatedAt = LocalDateTime.now();
   }
 
   public void updateAmount(long changedAmount) {

--- a/MSA-coin/src/main/java/com/joh/coin/service/OrderBookService.java
+++ b/MSA-coin/src/main/java/com/joh/coin/service/OrderBookService.java
@@ -42,14 +42,8 @@ public class OrderBookService {
             return Mono.empty(); // 매수량이 0이면 더 이상 진행하지 않음
           }
 
-          return findCompletedOrdersFromSameRequest(
-              sellOrderBook.getUserId(),
-              sellOrderBook.getCoinId(),
-              sellOrderBook.getPrice(),
-              sellOrderBook.getType(),
-              OrderStatus.COMPLETED.name(),
-              sellOrderBook.getCreatedAt()
-          )
+          return findCompletedOrdersFromSameRequestByStatus(sellOrderBook,
+              OrderStatus.COMPLETED.name())
               .flatMap(completedOrderBook -> { // 체결된 주문이 존재하는 경우
                 long sellAmount = sellOrderBook.getAmount();
 
@@ -208,12 +202,162 @@ public class OrderBookService {
         .onErrorMap(e -> new FindOrderBookDataException("매수할 OrderBook 조회 실패: " + e.getMessage()));
   }
 
-  public Mono<OrderBook> findCompletedOrdersFromSameRequest(String userId, Long coinId, Long price,
-      String type, String status, LocalDateTime createdAt) {
+  public Mono<OrderBook> findCompletedOrdersFromSameRequestByStatus(OrderBook orderBook,
+      String requestStatus) {
+    String userId = orderBook.getUserId();
+    Long coinId = orderBook.getCoinId();
+    Long price = orderBook.getPrice();
+    String type = orderBook.getType();
+    LocalDateTime createdAt = orderBook.getCreatedAt();
 
     return orderBookRepository.findByUserIdAndCoinIdAndPriceAndTypeAndStatusAndCreatedAt(
-            userId, coinId, price, type, status, createdAt
+            userId, coinId, price, type, requestStatus, createdAt
         )
         .onErrorMap(e -> new FindOrderBookDataException("체결된 OrderBook 조회 실패: " + e.getMessage()));
+  }
+
+  // 매도 메서드
+  public Mono<TradeOrderRes> sellCoin(String userId, TradeOrderReq tradeOrderReq) {
+
+    Long coinId = tradeOrderReq.getCoinId();
+    Long price = tradeOrderReq.getPrice();
+    Long amount = tradeOrderReq.getAmount();
+
+    AtomicReference<Long> amountToSell = new AtomicReference<>(amount);
+
+    // 매수 요청 데이터를 조회
+    return findPendingOrders(coinId, price, OrderType.BUY.name())
+        // 조회되는 데이터가 있으면 아래 메서드 실행
+        .concatMap(buyOrderBook -> {
+          if (amountToSell.get() == 0) {
+            return Mono.empty();
+          }
+
+          return findCompletedOrdersFromSameRequestByStatus(buyOrderBook,
+              OrderStatus.COMPLETED.name())
+              .flatMap(completedOrderBook -> { // 체결된 주문이 존재하는 경우
+                long buyAmount = buyOrderBook.getAmount();
+                long completedBuyAmount = completedOrderBook.getAmount();
+
+                // 요청한 매도량보다 매수량이 이상일 경우
+                if (amountToSell.get() <= buyAmount) {
+                  long restAmount = buyAmount - amountToSell.get();
+                  amountToSell.set(0L); // 어차피 0개가 됨
+
+                  // 딱 떨어지는 경우
+                  if (restAmount == 0) {
+                    completedOrderBook.updateAmount(buyAmount + completedBuyAmount);
+
+                    return orderBookRepository.delete(buyOrderBook)
+                        .then(orderBookRepository.save(completedOrderBook));
+                  }
+
+                  // 요청 매수량을 제해도 남는 경우
+                  completedOrderBook.updateAmount(completedBuyAmount + amountToSell.get());
+                  buyOrderBook.updateAmount(restAmount);
+
+                  return orderBookRepository.save(completedOrderBook)
+                      .then(orderBookRepository.save(buyOrderBook));
+                }
+
+                // 요청한 매도량이 매수량보다 클 경우
+                amountToSell.getAndUpdate(current -> current - buyAmount);
+                completedOrderBook.updateAmount(completedBuyAmount + buyAmount);
+
+                return orderBookRepository.delete(buyOrderBook)
+                    .then(orderBookRepository.save(completedOrderBook));
+
+              })
+              .switchIfEmpty(Mono.defer(() -> { // 체결된 주문이 조회되지 않을 때 처리
+                long buyAmount = buyOrderBook.getAmount();
+
+                // 요청한 매도량보다 매수량이 크거나 같을 때
+                if (amountToSell.get() <= buyAmount) {
+                  long restAmount = buyAmount - amountToSell.get();
+                  long currentAmountToSell = amountToSell.get();
+                  amountToSell.set(0L);
+
+                  // 딱 떨어질 떼
+                  if (restAmount == 0) {
+                    buyOrderBook.updateStatusToCompleted();
+
+                    return orderBookRepository.save(buyOrderBook);
+                  }
+
+                  buyOrderBook.updateAmount(restAmount);
+
+                  OrderBook completedBuyOrderBook = OrderBook.builder()
+                      .userId(buyOrderBook.getUserId())
+                      .coinId(buyOrderBook.getCoinId())
+                      .price(buyOrderBook.getPrice())
+                      .amount(currentAmountToSell)
+                      .type(buyOrderBook.getType())
+                      .status(OrderStatus.COMPLETED.name())
+                      .createdAt(buyOrderBook.getCreatedAt())
+                      .build();
+
+                  return orderBookRepository.save(buyOrderBook)
+                      .then(orderBookRepository.save(completedBuyOrderBook));
+                }
+
+                // 요청한 매도량이 더 클 경우
+                amountToSell.getAndUpdate(current -> current - buyAmount);
+                buyOrderBook.updateStatusToCompleted();
+
+                return orderBookRepository.save(buyOrderBook);
+              }))
+              .onErrorMap(e -> new OrderBookSaveException("매도 요청 처리 중 오류 발생: " + e.getMessage()));
+
+        })
+        .then(Mono.defer(() -> { // 모든 매도 매수 계산이 끝난 후
+          long restAmountToSell = amountToSell.get();
+          long completedAmountToSell = amount - restAmountToSell;
+          LocalDateTime nowTime = LocalDateTime.now();
+
+          OrderBook pendingOrderBook = OrderBook.builder()
+              .userId(userId)
+              .coinId(coinId)
+              .type(OrderType.SELL.name())
+              .amount(restAmountToSell)
+              .price(price)
+              .status(OrderStatus.PENDING.name())
+              .createdAt(nowTime)
+              .build();
+
+          OrderBook completedOrderBook = OrderBook.builder()
+              .userId(userId)
+              .coinId(coinId)
+              .type(OrderType.SELL.name())
+              .amount(completedAmountToSell)
+              .price(price)
+              .status(OrderStatus.COMPLETED.name())
+              .createdAt(nowTime)
+              .build();
+
+          // 매도한 게 없으면 그대로 PENDING 저장
+          if (completedAmountToSell == 0) {
+            return orderBookRepository.save(pendingOrderBook)
+                .thenReturn(new TradeOrderRes("매도 요청이 완료되었습니다. 주문이 PENDING 상태로 등록되었습니다."));
+          }
+
+          // 일부만 체결된 거면
+          if (amount > restAmountToSell && restAmountToSell > 0) {
+            coinWebSocketHandler.updatePrice("심볼을 받게 돼있는데 바꿔야 함", price);
+
+            return orderBookRepository.save(pendingOrderBook)
+                .then(orderBookRepository.save(completedOrderBook))
+                .thenReturn(new TradeOrderRes("매도 요청이 완료되었습니다. 일부 주문이 PENDING 상태로 등록되었습니다."));
+          }
+
+          // 모두 체결 됐을 때
+          completedOrderBook.setUpdatedAt(nowTime);
+          coinWebSocketHandler.updatePrice("심볼을 받게 돼있는데 바꿔야 함", price);
+
+          return orderBookRepository.save(completedOrderBook)
+              .thenReturn(new TradeOrderRes("매도 요청이 완료되었습니다. 모든 주문이 체결되었습니다."));
+
+        }))
+        .onErrorMap(e -> new OrderBookSaveException("남은 매도 요청 처리 중 오류 발생: " + e.getMessage()))
+        .as(transactionalOperator::transactional);
   }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feat/coin-basic-env -> main

### 변경 사항
- 매수 API를 추가하였습니다.

### 테스트 결과

1. 처음 데이터 상태
![image](https://github.com/user-attachments/assets/23ffffa5-9ba3-4571-8417-373ac3762f89)

---

2. 5개 매도 요청
![image](https://github.com/user-attachments/assets/d00d7e8b-67e1-4618-81a9-306e09244373)

---

3. 데이터 변화
![image](https://github.com/user-attachments/assets/0cade092-52c4-4e4a-abaa-bc5cdc427b02)

---

4. 3개 매도 요청
![image](https://github.com/user-attachments/assets/d095b18d-d668-4d47-8d7e-4531e3bc3203)

---

5. 데이터 변화
![image](https://github.com/user-attachments/assets/79cccb9c-92fc-46f0-9285-328a90794c18)

---

6. 1번 상태에서 딱 떨어지도록 매도를 요청했을 때
- 요청
![image](https://github.com/user-attachments/assets/afadaabe-8549-4434-bd91-2cdfdf8b3297)

- 결과
![image](https://github.com/user-attachments/assets/7875d132-951f-489a-8b31-a32b7c33be9b)
